### PR TITLE
Update overviewpage.cpp to fix balance

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -178,11 +178,11 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
     currentWatchImmatureBalance = watchImmatureBalance;
 
 
-    ui->labelBalance->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, balance - immatureBalance, false, BitcoinUnits::separatorAlways));
+    ui->labelBalance->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, balance, false, BitcoinUnits::separatorAlways));
     ui->labelUnconfirmed->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, unconfirmedBalance, false, BitcoinUnits::separatorAlways));
     ui->labelImmature->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, immatureBalance, false, BitcoinUnits::separatorAlways));
     ui->labelAnonymized->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, anonymizedBalance, false, BitcoinUnits::separatorAlways));
-    ui->labelTotal->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, balance + unconfirmedBalance, false, BitcoinUnits::separatorAlways));
+    ui->labelTotal->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, balance + immatureBalance + unconfirmedBalance, false, BitcoinUnits::separatorAlways));
 
 
     ui->labelWatchAvailable->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, watchOnlyBalance, false, BitcoinUnits::separatorAlways));


### PR DESCRIPTION
The balance in "Available" section of the Overview page was showing incorrectly. It kept removing coin balance as MN rewards came in (each time by 80 until the coins matured). This causes confusion because the user still has the original available/spendable balance but the wallet reports it wrong every time a MN reward is received. See attached images for reference of before and after.

BEFORE:
<img width="394" alt="before_testwage" src="https://user-images.githubusercontent.com/31451171/37880207-6f6ed0f6-304a-11e8-8a36-8685d29921d9.png">

AFTER:
<img width="377" alt="after_testwage" src="https://user-images.githubusercontent.com/31451171/37880206-6f5eab36-304a-11e8-9baf-e33756f8bf24.png">

